### PR TITLE
use Twitter profile pics from avatars.io

### DIFF
--- a/middleware/people.js
+++ b/middleware/people.js
@@ -55,11 +55,13 @@ function peopleFilledWithGenericInfos(rows) {
 	for (var i = 0; i < rows.length; i++) {
 		var row = rows[i]
 		if (row.length !== 0) {
+			var tw = row[2] && row[2].length ? row[2] : null;
+			var img = tw ? "//avatars.io/twitter/"+tw.toLowerCase()+"/large" : row[3];
 			var person = {
 				first_name: row[0],
 				last_name: row[1],
-				twitter: row[2],
-				image: row[3]
+				twitter: tw,
+				image: img
 			}
 			if (row[4] == 1) { // member
 				members.push(person)


### PR DESCRIPTION
Uses [avatars.io](https://www.avatars.io/) to fetch the Twitter profile pic for display on the Team page.

Needs a bit of testing but seems to be working fine. Before deploy I would suggest to check that the twitter usernames in the spreadsheet are correct, and to let people know that their Twitter pic will be used.