### PR TITLE
Enables Heroku Review Apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,10 @@
+{
+  "name": "mangrove-website",
+  "description": "Mangrove's inspiring website",
+  "keywords": ["mangrove"],
+  "website": "http://meetmangrove.com/",
+  "repository": "https://github.com/MeetMangrove/mangrove-website",
+  "success_url": "/",
+  "env": {},
+  "addons": []
+}


### PR DESCRIPTION
Review Apps are a Heroku feature which automatically creates a new (free) app for each Pull Request. People can visit the Review Apps to see what changes a PR makes and give feedback.

Example: see [this Review App](https://mangrovewebsite-davb-pr-1.herokuapp.com/) based on [this Pull Request](https://github.com/davb/mangrove-website/pull/1) (on my own fork)

### How to enable Review Apps on this repo

*Must be done from the app owner account*

  1. Merge this PR. I hope you like it :)

  1. Go to [the `mangrovewebsite` app on Heroku Dashboard](https://dashboard.heroku.com/apps/mangrovewebsite/deploy/heroku-git), under the Deploy tab

  1. Click "New Pipeline" and create a Pipeline (e.g. `mangrovewebsite-pipeline`)

  1. On the new Pipeline's page, click "Connect to GitHub", and connect the Pipeline to the `MeetMangrove/mangrove-website` repo

  1. Click "Enable Review Apps". Heroku should detect that there is an `app.json` file on the `master` branch

  1. Check "Create new review apps for new pull requests automatically"

Done! Every time a PR is updated you'll see a notification like this:
![just_a_pr_to_demo_review_apps_by_davb_ _pull_request__1_ _davb_mangrove-website](https://cloud.githubusercontent.com/assets/1025217/21286952/ab51e6ae-c461-11e6-91e5-318f9f1a8c7b.png)
