### PR TITLE
Fixes main catchphrase on mobile centering

### DIFF
--- a/public/stylesheets/global.css
+++ b/public/stylesheets/global.css
@@ -30,7 +30,8 @@ h1 {
   right: 0
   left: 0;
   margin: 0;
-  padding: 0 20px;
+  padding: 0;
+  width: 100%;
 }
 
 @-webkit-keyframes move-arrow {


### PR DESCRIPTION
![screenshot_20170209-122156](https://cloud.githubusercontent.com/assets/1388511/22807756/c9187654-eee5-11e6-91a0-eb52a44d1e96.png)

This should fix the above bug by centering the catchphrase.